### PR TITLE
Add `.rustfmt.toml` config

### DIFF
--- a/.rustfmt.toml
+++ b/.rustfmt.toml
@@ -1,0 +1,5 @@
+edition = "2018"
+max_width = 80
+tab_spaces = 2
+use_field_init_shorthand = true
+use_try_shorthand = true

--- a/.rustfmt.toml
+++ b/.rustfmt.toml
@@ -2,4 +2,3 @@ edition = "2018"
 max_width = 80
 tab_spaces = 2
 use_field_init_shorthand = true
-use_try_shorthand = true

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,5 @@
 mod snek;
 
 fn main() {
-    snek::foo::foo();
+  snek::foo::foo();
 }


### PR DESCRIPTION
Copied over stable configs from [my `rustfmt.toml`](https://github.com/nathanshelly/.files/blob/master/languages/rust/rustfmt.toml.symlink). Open to any and all changes here, just a starting point.

Could be interesting to test out some unstable configs as well ([here](https://github.com/nathanshelly/.files/blob/master/languages/rust/rustfmt.toml.symlink#L9) are ones I like).