### PR TITLE
Guard pre-commit symlink & shellcheck installation

### DIFF
--- a/bin/setup-dev.sh
+++ b/bin/setup-dev.sh
@@ -5,7 +5,7 @@ set -euo pipefail
 # Symlink pre-commit hooks
 root=$(git rev-parse --show-toplevel)
 pushd "$root/.git/hooks"
-ln -s ../../.githooks/pre-commit pre-commit
+ln -sf ../../.githooks/pre-commit pre-commit
 popd
 
 # Install [clippy](https://github.com/rust-lang/rust-clippy), which only works on nightly

--- a/bin/setup-dev.sh
+++ b/bin/setup-dev.sh
@@ -13,4 +13,4 @@ rustup toolchain add nightly
 rustup component add clippy --toolchain nightly
 
 # [shellcheck](https://github.com/koalaman/shellcheck)
-brew install shellcheck
+command -v shellcheck > /dev/null || brew install shellcheck


### PR DESCRIPTION
Force symlink pre-commit hooks and conditionally install shellcheck

Prompted by switching `rust` installations to `asdf-rust` and trying to run our setup script