### PR TITLE
Add command-line args

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "snek"
 version = "0.1.0"
-authors = ["sashaweiss <asashaweiss@gmail.com>"]
+authors = ["sashaweiss <asashaweiss@gmail.com>", "nathanshelly <nsnshelly@gmail.com>"]
 edition = "2018"
 
 [dependencies]
@@ -9,3 +9,4 @@ tui = "0.8"
 termion = "1.5"
 rand = "0.7"
 crossbeam-channel = "0.4"
+clap = { git = "https://github.com/clap-rs/clap/" }

--- a/src/input.rs
+++ b/src/input.rs
@@ -1,6 +1,6 @@
 use clap::Clap;
 
-use crate::snek::GameConfig;
+use crate::snek::Config;
 
 /// Play the classic game snake! 🐍
 #[derive(Clap, Debug)]
@@ -11,12 +11,12 @@ pub struct Input {
   food_count: Option<usize>,
 }
 
-impl Into<GameConfig> for Input {
-  fn into(self) -> GameConfig {
-    let mut builder = GameConfig::default();
+impl Into<Config> for Input {
+  fn into(self) -> Config {
+    let mut builder = Config::default();
 
     if let Some(food_count) = self.food_count {
-      builder.food_count = food_count
+      builder.game_config.food_count = food_count
     }
 
     builder

--- a/src/input.rs
+++ b/src/input.rs
@@ -1,0 +1,24 @@
+use clap::Clap;
+
+use crate::snek::GameConfig;
+
+/// Play the classic game snake! 🐍
+#[derive(Clap, Debug)]
+#[clap(version = "0.1", author = "Nathan Shelly & Sasha Weiss")]
+pub struct Input {
+  /// Sets the amount of food on the board at any given time
+  #[clap(long = "food-count")]
+  food_count: Option<usize>,
+}
+
+impl Into<GameConfig> for Input {
+  fn into(self) -> GameConfig {
+    let mut builder = GameConfig::default();
+
+    if let Some(food_count) = self.food_count {
+      builder.food_count = food_count
+    }
+
+    builder
+  }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,9 +1,13 @@
+mod input;
 mod snek;
 
-fn main() {
-  let mut d = snek::driver::Driver::new();
+use clap::Clap;
 
-  d.drive()
+use crate::snek::Driver;
+use input::Input;
+
+fn main() {
+  Driver::play_with_config(Input::parse().into())
     .map_err(|err| eprintln!("Driver returned with an error: {:?}", err))
     .unwrap();
 }

--- a/src/snek/args.rs
+++ b/src/snek/args.rs
@@ -1,8 +1,0 @@
-/// Play the classic game snake! 🐍
-#[derive(Clap, Debug)]
-#[clap(version = "0.1", author = "Nathan Shelly & Sasha Weiss")]
-pub struct Args {
-  /// Sets the amount of food on the board at any given time
-  #[clap(long = "food-count")]
-  food_count: Option<i32>,
-}

--- a/src/snek/args.rs
+++ b/src/snek/args.rs
@@ -1,0 +1,8 @@
+/// Play the classic game snake! 🐍
+#[derive(Clap, Debug)]
+#[clap(version = "0.1", author = "Nathan Shelly & Sasha Weiss")]
+pub struct Args {
+  /// Sets the amount of food on the board at any given time
+  #[clap(long = "food-count")]
+  food_count: Option<i32>,
+}

--- a/src/snek/driver.rs
+++ b/src/snek/driver.rs
@@ -8,6 +8,7 @@ use termion::event::Key;
 use termion::input::TermRead;
 
 pub struct Driver {
+  config: GameConfig,
   term: Terminal,
   game: Game,
   paused: bool,
@@ -31,6 +32,15 @@ pub(crate) enum Direction {
 }
 
 impl Driver {
+  pub fn play() -> Result<(), ()> {
+    Self::play_with_config(GameConfig::default())
+  }
+
+  pub fn play_with_config(config: GameConfig) -> Result<(), ()> {
+    eprintln!("{:?}", config);
+    Self::new(config).drive()
+  }
+
   pub fn new() -> Self {
     let term = Terminal::new();
     let game_space = term.game_space();
@@ -161,5 +171,15 @@ impl From<Key> for UserAction {
       Key::Esc | Key::Ctrl('c') => Self::Quit,
       _ => Self::None,
     }
+  }
+}
+
+#[derive(Debug)]
+pub struct GameConfig {
+  pub food_count: usize,
+}
+impl Default for GameConfig {
+  fn default() -> Self {
+    Self { food_count: 1 }
   }
 }

--- a/src/snek/driver.rs
+++ b/src/snek/driver.rs
@@ -8,7 +8,6 @@ use termion::event::Key;
 use termion::input::TermRead;
 
 pub struct Driver {
-  config: GameConfig,
   term: Terminal,
   game: Game,
   paused: bool,
@@ -33,12 +32,12 @@ pub(crate) enum Direction {
 
 impl Driver {
   pub fn play() -> Result<(), ()> {
-    Self::play_with_config(GameConfig::default())
+    Self::play_with_config(Config::default())
   }
 
-  pub fn play_with_config(config: GameConfig) -> Result<(), ()> {
+  pub fn play_with_config(config: Config) -> Result<(), ()> {
     eprintln!("{:?}", config);
-    Self::new(config).drive()
+    Self::new().drive(config)
   }
 
   pub fn new() -> Self {
@@ -181,5 +180,17 @@ pub struct GameConfig {
 impl Default for GameConfig {
   fn default() -> Self {
     Self { food_count: 1 }
+  }
+}
+
+#[derive(Debug)]
+pub struct Config {
+  pub game_config: GameConfig,
+}
+impl Default for Config {
+  fn default() -> Self {
+    Self {
+      game_config: GameConfig::default(),
+    }
   }
 }

--- a/src/snek/driver.rs
+++ b/src/snek/driver.rs
@@ -30,6 +30,16 @@ pub(crate) enum Direction {
   West,
 }
 
+#[derive(Debug)]
+pub struct GameConfig {
+  pub food_count: usize,
+}
+
+#[derive(Debug)]
+pub struct Config {
+  pub game_config: GameConfig,
+}
+
 impl Driver {
   pub fn play() -> Result<()> {
     Self::play_with_config(Config::default())
@@ -172,20 +182,10 @@ impl From<Key> for UserAction {
   }
 }
 
-#[derive(Debug)]
-pub struct GameConfig {
-  pub food_count: usize,
-}
-
 impl Default for GameConfig {
   fn default() -> Self {
     Self { food_count: 1 }
   }
-}
-
-#[derive(Debug)]
-pub struct Config {
-  pub game_config: GameConfig,
 }
 
 impl Default for Config {

--- a/src/snek/driver.rs
+++ b/src/snek/driver.rs
@@ -176,6 +176,7 @@ impl From<Key> for UserAction {
 pub struct GameConfig {
   pub food_count: usize,
 }
+
 impl Default for GameConfig {
   fn default() -> Self {
     Self { food_count: 1 }
@@ -186,6 +187,7 @@ impl Default for GameConfig {
 pub struct Config {
   pub game_config: GameConfig,
 }
+
 impl Default for Config {
   fn default() -> Self {
     Self {

--- a/src/snek/driver.rs
+++ b/src/snek/driver.rs
@@ -36,7 +36,6 @@ impl Driver {
   }
 
   pub fn play_with_config(config: Config) -> Result<(), ()> {
-    eprintln!("{:?}", config);
     Self::new().drive(config)
   }
 

--- a/src/snek/driver.rs
+++ b/src/snek/driver.rs
@@ -31,22 +31,22 @@ pub(crate) enum Direction {
 }
 
 impl Driver {
-  pub fn play() -> Result<(), ()> {
+  pub fn play() -> Result<()> {
     Self::play_with_config(Config::default())
   }
 
-  pub fn play_with_config(config: Config) -> Result<(), ()> {
-    Self::new().drive(config)
+  pub fn play_with_config(config: Config) -> Result<()> {
+    Self::new(config).drive()
   }
 
-  pub fn new() -> Self {
+  pub fn new(config: Config) -> Self {
     let term = Terminal::new();
     let game_space = term.game_space();
 
     Driver {
       term,
       paused: false,
-      game: Game::new(game_space),
+      game: Game::new(config.game_config, game_space),
     }
   }
 

--- a/src/snek/food.rs
+++ b/src/snek/food.rs
@@ -1,6 +1,22 @@
+use rand::{
+  distributions::{Distribution, Standard},
+  Rng,
+};
+
 #[derive(Debug, Copy, Clone)]
 pub(crate) enum Food {
   Mouse,
   Cherry,
   Cake,
+}
+
+// ref - https://stackoverflow.com/a/48491021
+impl Distribution<Food> for Standard {
+  fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> Food {
+    match rng.gen_range(0, 3) {
+      0 => Food::Mouse,
+      1 => Food::Cherry,
+      _ => Food::Cake,
+    }
+  }
 }

--- a/src/snek/game.rs
+++ b/src/snek/game.rs
@@ -1,4 +1,4 @@
-use crate::snek::driver::{Direction, UserAction};
+use crate::snek::driver::{GameConfig, Direction, UserAction};
 use crate::snek::food::Food;
 use crate::snek::snake::Snake;
 use rand::Rng;
@@ -30,8 +30,8 @@ pub(crate) struct Game {
 }
 
 impl Game {
-  pub fn new(dimensions: GameDimensions) -> Self {
-    let food = vec![Food::Cake, Food::Cherry, Food::Mouse]
+  pub fn new(config: GameConfig, dimensions: GameDimensions) -> Self {
+    let food = vec![rand::random(); config.food_count]
       .into_iter()
       .map(|food| (food, GameCoordinate::random(dimensions)))
       .collect();
@@ -157,9 +157,10 @@ mod tests {
     let width = 10;
     let height = 10;
 
-    let game = Game::new(GameDimensions { width, height });
+    let game =
+      Game::new(GameConfig::default(), GameDimensions { width, height });
 
-    assert_eq!(game.food().count(), 3);
+    assert_eq!(game.food().count(), 1);
     assert_eq!(game.dimensions(), GameDimensions { width, height });
   }
 }

--- a/src/snek/game.rs
+++ b/src/snek/game.rs
@@ -1,4 +1,4 @@
-use crate::snek::driver::{GameConfig, Direction, UserAction};
+use crate::snek::driver::{Direction, GameConfig, UserAction};
 use crate::snek::food::Food;
 use crate::snek::snake::Snake;
 use rand::Rng;

--- a/src/snek/mod.rs
+++ b/src/snek/mod.rs
@@ -1,8 +1,8 @@
 #![allow(clippy::trivially_copy_pass_by_ref)]
 #![allow(dead_code)] // TODO: @sashaweiss @nathanshelly remove this once MVP is working
 
-extern crate crossbeam_channel;
 extern crate clap;
+extern crate crossbeam_channel;
 extern crate rand;
 extern crate tui;
 

--- a/src/snek/mod.rs
+++ b/src/snek/mod.rs
@@ -12,4 +12,4 @@ mod game;
 mod snake;
 mod terminal;
 
-pub use driver::{Driver, GameConfig};
+pub use driver::{Config, Driver};

--- a/src/snek/mod.rs
+++ b/src/snek/mod.rs
@@ -2,11 +2,14 @@
 #![allow(dead_code)] // TODO: @sashaweiss @nathanshelly remove this once MVP is working
 
 extern crate crossbeam_channel;
+extern crate clap;
 extern crate rand;
 extern crate tui;
 
-pub mod driver;
+mod driver;
 mod food;
 mod game;
 mod snake;
 mod terminal;
+
+pub use driver::{Driver, GameConfig};


### PR DESCRIPTION
Only current accepted argument is `food-count` to specify the number of
pieces of food on-screen at once.

Closes #36

[![asciicast](https://asciinema.org/a/JkRlWJ4EzElveKDeTFadtB6F5.svg)](https://asciinema.org/a/JkRlWJ4EzElveKDeTFadtB6F5)